### PR TITLE
Bug fixes for goals, and more detailed exporting

### DIFF
--- a/Readme.mdown
+++ b/Readme.mdown
@@ -26,8 +26,16 @@ and require it in your project:
 
 ## Usage
 
+This exports data for all experiments. This data set does not break down conversions by goals:
+
     require 'split/export'
     csv_data = Split::Export.to_csv
+    File.open('path/to/my.csv', 'w') {|f| f.write(csv_data) }
+
+This exports data for a single experiment, and breaks it down by group and goal:
+
+    require 'split/export'
+    csv_data = Split::Export.experiment_to_csv("my_experiment")
     File.open('path/to/my.csv', 'w') {|f| f.write(csv_data) }
 
 ## Development

--- a/lib/split/export.rb
+++ b/lib/split/export.rb
@@ -21,7 +21,7 @@ module Split
                     alternative.name,
                     alternative.participant_count,
                     goals.inject(0) { |sum, g| sum + alternative.completed_count(g) },
-                    round(goals.inject(0) { |sum, g| alternative.conversion_rate(g) }, 3),
+                    round(goals.inject(0) { |sum, g| sum + alternative.conversion_rate(g) }, 3),
                     round(alternative.z_score, 3),
                     alternative.control?,
                     alternative.to_s == experiment.winner.to_s]

--- a/lib/split/export.rb
+++ b/lib/split/export.rb
@@ -49,7 +49,7 @@ module Split
 
     def experiment_to_csv(experiment)
       csv = CSV.generate do |csv|
-        csv << %w(Alternative Goal Participants Completed Conversion\ Rate Z\ Score Control Winner)
+        csv << ["Alternative", "Goal", "Participants", "Completed", "Conversion Rate", "Z Score", "Control", "Winner"]
 
         experiment = Split::ExperimentCatalog.find(experiment)
 

--- a/lib/split/export.rb
+++ b/lib/split/export.rb
@@ -29,5 +29,30 @@ module Split
         end
       end
     end
+
+    def experiment_to_csv(experiment)
+      csv = CSV.generate do |csv|
+        csv << %w(Alternative Goal Participants Completed Conversion\ Rate Z\ Score Control Winner)
+
+        experiment = Split::ExperimentCatalog.find(experiment)
+
+        break if !experiment
+
+        goals = [nil] + experiment.goals # nil corresponds to conversions without any goals.
+
+        experiment.alternatives.each do |alternative|
+          goals.each do |goal|
+            csv << [alternative.name,
+                    goal,
+                    alternative.participant_count,
+                    alternative.completed_count(goal),
+                    alternative.conversion_rate(goal),
+                    alternative.z_score(goal),
+                    alternative.control?,
+                    alternative.to_s == experiment.winner.to_s]
+          end
+        end
+      end
+    end
   end
 end

--- a/lib/split/export.rb
+++ b/lib/split/export.rb
@@ -21,7 +21,7 @@ module Split
                     alternative.name,
                     alternative.participant_count,
                     goals.inject(0) { |sum, g| sum + alternative.completed_count(g) },
-                    round(alternative.conversion_rate, 3),
+                    round(goals.inject(0) { |sum, g| alternative.conversion_rate(g) }, 3),
                     round(alternative.z_score, 3),
                     alternative.control?,
                     alternative.to_s == experiment.winner.to_s]

--- a/lib/split/export.rb
+++ b/lib/split/export.rb
@@ -14,11 +14,13 @@ module Split
       csv = CSV.generate do |csv|
         csv << ['Experiment', 'Alternative', 'Participants', 'Completed', 'Conversion Rate', 'Z score', 'Control', 'Winner']
         Split::ExperimentCatalog.all.each do |experiment|
+          goals = experiment.goals + [nil] # nil corresponds to conversions without any goals.
+
           experiment.alternatives.each do |alternative|
             csv << [experiment.name,
                     alternative.name,
                     alternative.participant_count,
-                    alternative.completed_count,
+                    goals.inject(0) { |sum, g| sum + alternative.completed_count(g) },
                     round(alternative.conversion_rate, 3),
                     round(alternative.z_score, 3),
                     alternative.control?,

--- a/lib/split/export/version.rb
+++ b/lib/split/export/version.rb
@@ -1,5 +1,5 @@
 module Split
   module Export
-    VERSION = "1.1.0"
+    VERSION = "1.1.1"
   end
 end

--- a/spec/export_spec.rb
+++ b/spec/export_spec.rb
@@ -4,22 +4,22 @@ describe Split::Export do
   before :each do
     experiment = Split::ExperimentCatalog.find_or_create({'link_color': ["control", "goal"]}, 'blue', 'red', 'green')
     blue = Split::Alternative.new('blue', 'link_color')
-    blue.participant_count = 5
-    blue.set_completed_count(2, "control")
-    blue.set_completed_count(1, "goal")
+    blue.participant_count = 50
+    blue.set_completed_count(20, "control")
+    blue.set_completed_count(10, "goal")
     blue.save
     red = Split::Alternative.new('red', 'link_color')
-    red.participant_count = 6
-    red.set_completed_count(2, "control")
-    red.set_completed_count(2, "goal")
+    red.participant_count = 60
+    red.set_completed_count(10, "control")
+    red.set_completed_count(30, "goal")
     red.save
   end
 
   it "should generate a csv of split data" do
-    Split::Export.to_csv.should eql("Experiment,Alternative,Participants,Completed,Conversion Rate,Z score,Control,Winner\nlink_color,blue,5,3,0.6,0.0,true,false\nlink_color,red,6,4,0.667,0.0,false,false\nlink_color,green,0,0,0.0,0.0,false,false\n")
+    Split::Export.to_csv.should eql("Experiment,Alternative,Participants,Completed,Conversion Rate,Z score,Control,Winner\nlink_color,blue,50,30,0.6,0.0,true,false\nlink_color,red,60,40,0.667,0.724,false,false\nlink_color,green,0,0,0.0,0.0,false,false\n")
   end
 
   it "should generate a detailed csv of split data for a single table" do
-    Split::Export.experiment_to_csv("link_color").should eql("Alternative,Goal,Participants,Completed,Conversion Rate,Z Score,Control,Winner\nblue,,5,0,0.0,N/A,true,false\nblue,control,5,2,0.4,N/A,true,false\nblue,goal,5,1,0.2,N/A,true,false\nred,,6,0,0.0,Needs 30+ participants.,false,false\nred,control,6,2,0.3333333333333333,Needs 30+ participants.,false,false\nred,goal,6,2,0.3333333333333333,Needs 30+ participants.,false,false\ngreen,,0,0,0,Needs 30+ participants.,false,false\ngreen,control,0,0,0,Needs 30+ participants.,false,false\ngreen,goal,0,0,0,Needs 30+ participants.,false,false\n")
+    Split::Export.experiment_to_csv("link_color").should eql("Alternative,Goal,Participants,Completed,Conversion Rate,Z Score,Control,Winner\nblue,,50,0,0.0,0.0,true,false\nblue,control,50,20,0.4,0.0,true,false\nblue,goal,50,10,0.2,0.0,true,false\nred,,60,0,0.0,0.0,false,false\nred,control,60,10,0.167,-2.736,false,false\nred,goal,60,30,0.5,3.257,false,false\ngreen,,0,0,0.0,0.0,false,false\ngreen,control,0,0,0.0,0.0,false,false\ngreen,goal,0,0,0.0,0.0,false,false\n")
   end
 end

--- a/spec/export_spec.rb
+++ b/spec/export_spec.rb
@@ -2,18 +2,24 @@ require 'spec_helper'
 
 describe Split::Export do
   before :each do
-    experiment = Split::ExperimentCatalog.find_or_create('link_color', 'blue', 'red', 'green')
+    experiment = Split::ExperimentCatalog.find_or_create({'link_color': ["control", "goal"]}, 'blue', 'red', 'green')
     blue = Split::Alternative.new('blue', 'link_color')
     blue.participant_count = 5
-    blue.set_completed_count(3)
+    blue.set_completed_count(2, "control")
+    blue.set_completed_count(1, "goal")
     blue.save
     red = Split::Alternative.new('red', 'link_color')
     red.participant_count = 6
-    red.set_completed_count(4)
+    red.set_completed_count(2, "control")
+    red.set_completed_count(2, "goal")
     red.save
   end
 
   it "should generate a csv of split data" do
     Split::Export.to_csv.should eql("Experiment,Alternative,Participants,Completed,Conversion Rate,Z score,Control,Winner\nlink_color,blue,5,3,0.6,0.0,true,false\nlink_color,red,6,4,0.667,0.0,false,false\nlink_color,green,0,0,0.0,0.0,false,false\n")
+  end
+
+  it "should generate a detailed csv of split data for a single table" do
+    Split::Export.experiment_to_csv("link_color").should eql("Alternative,Goal,Participants,Completed,Conversion Rate,Z Score,Control,Winner\nblue,,5,0,0.0,N/A,true,false\nblue,control,5,2,0.4,N/A,true,false\nblue,goal,5,1,0.2,N/A,true,false\nred,,6,0,0.0,Needs 30+ participants.,false,false\nred,control,6,2,0.3333333333333333,Needs 30+ participants.,false,false\nred,goal,6,2,0.3333333333333333,Needs 30+ participants.,false,false\ngreen,,0,0,0,Needs 30+ participants.,false,false\ngreen,control,0,0,0,Needs 30+ participants.,false,false\ngreen,goal,0,0,0,Needs 30+ participants.,false,false\n")
   end
 end

--- a/spec/export_spec.rb
+++ b/spec/export_spec.rb
@@ -22,4 +22,8 @@ describe Split::Export do
   it "should generate a detailed csv of split data for a single table" do
     Split::Export.experiment_to_csv("link_color").should eql("Alternative,Goal,Participants,Completed,Conversion Rate,Z Score,Control,Winner\nblue,,50,0,0.0,0.0,true,false\nblue,control,50,20,0.4,0.0,true,false\nblue,goal,50,10,0.2,0.0,true,false\nred,,60,0,0.0,0.0,false,false\nred,control,60,10,0.167,-2.736,false,false\nred,goal,60,30,0.5,3.257,false,false\ngreen,,0,0,0.0,0.0,false,false\ngreen,control,0,0,0.0,0.0,false,false\ngreen,goal,0,0,0.0,0.0,false,false\n")
   end
+
+  it "should quietly return nil if a bad experiment name is passed in" do
+    Split::Export.experiment_to_csv("incorrect_name").should be_nil
+  end
 end


### PR DESCRIPTION
This fixes bug #11 when exporting data for experiments with goals.

This also introduces the `Export#experiment_to_csv` method, which allows one to export more detailed information on a single experiment. This information includes a full breakdown of all goals in an experiment. Returns nil if name is invalid.

The tests were also modified. First, I increased the sample sizes by a factor of 10. The numbers were so low that the Z scores were all zero, so they effectively weren't being tested for. I also added goals for existing conversions to make that testable.

Finally, sorry about changing the version number. I didn't get all the way through the readme file on the first reading.