### PR TITLE
#13 Rescue from ArgumentError when passing string into BigDecimal.new

### DIFF
--- a/lib/split/export.rb
+++ b/lib/split/export.rb
@@ -8,6 +8,8 @@ module Split
 
     def round(number, precision = 2)
       BigDecimal.new(number.to_s).round(precision).to_f
+    rescue ArgumentError
+      0.0
     end
 
     # this method calculates the z_score for an alternative including all goals. This behavior should


### PR DESCRIPTION
The reason of this bug is simple: old version of BigDecimal handled strings for us. Now they return exception. You can find more info in bigdecimal repository.

https://github.com/splitrb/split-export/issues/13